### PR TITLE
syntax_highlighter.cpp: add missing cstring header

### DIFF
--- a/src/features/SyntaxHighlighter/syntax_highlighter.cpp
+++ b/src/features/SyntaxHighlighter/syntax_highlighter.cpp
@@ -5,6 +5,7 @@
 #endif
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 
 using namespace ftxui;
 


### PR DESCRIPTION
Fixes build error with the current master:
```
/opt/local/var/macports/build/pnana-97f7a994/work/PNANA-ea3ea49f1551501a81acea40c192354c237756f6/src/features/SyntaxHighlighter/syntax_highlighter.cpp: In member function 'std::vector<pnana::features::Token> pnana::features::SyntaxHighlighter::tokenizeMeson(const std::string&)':
/opt/local/var/macports/build/pnana-97f7a994/work/PNANA-ea3ea49f1551501a81acea40c192354c237756f6/src/features/SyntaxHighlighter/syntax_highlighter.cpp:4681:13: error: 'strchr' was not declared in this scope
 4681 |         if (strchr("()[]{},.:;=+-*/%!&|^~<>?", line[i])) {
      |             ^~~~~~
/opt/local/var/macports/build/pnana-97f7a994/work/PNANA-ea3ea49f1551501a81acea40c192354c237756f6/src/features/SyntaxHighlighter/syntax_highlighter.cpp:8:1: note: 'strchr' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
    7 | #include <cctype>
  +++ |+#include <cstring>
    8 | 
make[2]: *** [CMakeFiles/pnana.dir/src/features/SyntaxHighlighter/syntax_highlighter.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory `/opt/local/var/macports/build/pnana-97f7a994/work/build'
make[1]: *** [CMakeFiles/pnana.dir/all] Error 2
```