### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,6 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Cyxuan0311/PNANA&type=Date)](https://star-history.com/#Cyxuan0311/PNANA&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Cyxuan0311/PNANA&type=Date)](https://star-history.dera.page/#Cyxuan0311/PNANA&Date)
 
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -181,4 +181,4 @@ pnana --theme dracula file.txt
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Cyxuan0311/PNANA&type=Date)](https://star-history.com/#Cyxuan0311/PNANA&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Cyxuan0311/PNANA&type=Date)](https://star-history.dera.page/#Cyxuan0311/PNANA&Date)


### PR DESCRIPTION
The Star History chart in README.md and README_CN.md is currently broken because of GitHub stargazer API restrictions on the old provider. This PR switches the chart to star-history.dera.page, an alternative that uses a different data source and does not require an API token, restoring the chart for this repository.